### PR TITLE
fix: include id-token permission

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,7 @@ permissions:
   issues: write
   pull-requests: write
   packages: write
+  id-token: write
 
 env:
   SEMANTIC_VERSION: 19


### PR DESCRIPTION
By default, GHA don't have their OIDC ID token injected into the
environment. You need this permission to let the runtime inject the ID
token and appropriate environment variables.