### PR TITLE
fix: Strip debug information from binary

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ COPY pkg/ pkg/
 # was called. For example, if we call make docker-build in a local env which has the Apple Silicon M1 SO
 # the docker BUILDPLATFORM arg will be linux/arm64 when for Apple x86 it will be linux/amd64. Therefore,
 # by leaving it empty we can ensure that the container and binary shipped on it will have the same platform.
-RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o manager main.go
+RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o manager -ldflags="-w -s" main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details


### PR DESCRIPTION
```
⇒  go tool link
  -s    disable symbol table
  -w    disable DWARF generation
```

Removing debugger information results in a ~29% decrease in container
size.

```
infrakit-stripped             latest            2ce09e1ecc34   8 minutes ago    39.9MB
infrakit                      latest            b72098a6bcec   18 minutes ago   56MB
```
