### PR TITLE
build: Speed up ARM builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.19 as builder
+FROM --platform=$BUILDPLATFORM golang:1.19 as builder
 ARG TARGETOS
 ARG TARGETARCH
 


### PR DESCRIPTION
Make ARM based builds faster by ensuring that golang container that's
used to build the ARM based binary is also ARM based.

Some quick testing (which did NOT include push time) saw builds drop by
a little over 10 minutes per build.