### PR TITLE
build: Cache modules and test artifacts

### DIFF
--- a/.github/workflows/go-tests.yml
+++ b/.github/workflows/go-tests.yml
@@ -12,6 +12,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
       - name: bootstrap
         uses: ./.github/actions/bootstrap
         with:


### PR DESCRIPTION
We're currently redownloading the modules every time which is taking the
majority of the time when running this workflow.

This lowers go-test time from about 4 minutes to as low as 1m20s.