### PR TITLE
build: Specify which qemu platforms to use

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,8 @@ jobs:
           fetch-depth: 0
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
+        with:
+          platforms: linux/amd64,linux/arm64
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
       - name: Semantic Release dry run


### PR DESCRIPTION
Instead of setting up all platforms, only setup the ones that are
actually targeted for builds.
